### PR TITLE
Add an Initial User

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   cities = City.create([{ :name => 'Chicago' }, { :name => 'Copenhagen' }])
 #   Mayor.create(:name => 'Daley', :city => cities.first)
+
+user = User.create! :email => 'admin@mydomain.com', :access_level => 'admin', 
+:nickname => 'Admin', :real_name => 'Site Administrator', 
+:password => 'sesame', :password_confirmation => 'sesame'


### PR DESCRIPTION
This commit just puts an initial admin user account in the seed data, so that it is easy to log in into fresh instances of the app.

Please discard if you don't think this is a good idea.
