### PR TITLE
Addition related to User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,6 +51,9 @@ class User < ActiveRecord::Base
     
   has_many :exam_submissions, :dependent => :delete_all
   has_many :exams,            :through => :exam_submissions
+  
+  scope :insufficient_information, 
+        :conditions => ["(real_name = '' OR real_name IS NULL) AND (nickname = '' OR nickname IS NULL)"]
 
   def self.search(search, page)
     sql_condition = %w(email real_name nickname twitter_account_name github_account_name).

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -24,4 +24,13 @@ namespace :users do
                                         :submission_status_id => status.id)
     end
   end
+  
+  task :update_nickname => :environment do
+    User.insufficient_information.each do |missing_info_user|
+      nickname = missing_info_user.email[/([^\@]*)@.*/,1]
+      missing_info_user.nickname = nickname
+      missing_info_user.save!
+    end
+    
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -56,4 +56,19 @@ class UserTest < ActiveSupport::TestCase
     assert user.save
   end
   
+  test "name should return nickname if available" do
+    user = User.new(@attrs)
+    assert_equal @attrs[:nickname], user.name
+  end
+  
+  test "name should return real name if nickname is not available" do
+    user = User.new(@attrs.merge(:nickname => ""))
+    assert_equal @attrs[:real_name], user.name
+  end
+  
+  test "name should return email id if both nickname and real name are not available" do
+    user = User.new(@attrs.merge(:nickname => "", :real_name => ""))
+    assert_equal "one", user.name
+  end
+  
 end


### PR DESCRIPTION
I added 3 tests for User#name. I also added a rake task that iterates through users that don't have real_name & nickname populated and sets their nickname to be based on their email. With this, we can take away the else case once we run the task against the production database.
