### PR TITLE
Viewing of Channel Discussion Topics

### DIFF
--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -4,7 +4,7 @@ class Chat::MessagesController < ApplicationController
   before_filter      :find_channel,       :only  => [:index, :discussions]
   skip_before_filter :authenticate_user!
   skip_before_filter :change_password_if_needed
-  before_filter      :authenticate_service, :only => [:create]
+  before_filter      :authenticate_service, :only => [:create, :discussion_topic_path]
 
   def index
     unless @channel
@@ -95,6 +95,15 @@ class Chat::MessagesController < ApplicationController
                                          :topic_id    => topic_id)
                                        
     render :json => chat_message.to_json
+  end
+
+  def discussion_topic_url
+    channel = Chat::Channel.find_by_name(params[:channel])
+    topic   = Chat::Topic.find_by_name(params[:topic])
+
+    url  = chat_messages_url(:channel => channel.name, :topic => topic.name)
+
+    render :text => url
   end
   
   def transcripts

--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -74,7 +74,9 @@ class Chat::MessagesController < ApplicationController
       return
     end
 
-    @discussions = @channel.topics.order("created_at desc")
+    params[:sort] ||= 'created_at'
+    @discussion_orders = Chat::Topic::SORT_ORDERS
+    @discussions = @channel.topics.sort_order_by(params[:sort])
   end
   
   def create

--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -21,11 +21,11 @@ class Chat::MessagesController < ApplicationController
       return
     end
     
-    topic = @channel.topics.find_by_name(params[:topic]) if params[:topic]
+    @topic = @channel.topics.find_by_name(params[:topic]) if params[:topic]
 
     @messages = @channel.messages.order("recorded_at DESC")
                               
-    @messages = @messages.where(:topic_id => topic.id) if topic
+    @messages = @messages.where(:topic_id => @topic.id) if @topic
     
     if params[:since] && !params[:since].blank?
       @messages = @messages.where(["recorded_at > ? AND chat_messages.id <> ?", 
@@ -57,6 +57,10 @@ class Chat::MessagesController < ApplicationController
         render :json => json_messages.to_json
       end
     end
+  end
+
+  def discussions
+    @discussions = Channel.find_by_name(params[:channel]).topics
   end
   
   def create

--- a/app/models/chat/topic.rb
+++ b/app/models/chat/topic.rb
@@ -1,4 +1,17 @@
 class Chat::Topic < ActiveRecord::Base
+  SORT_ORDERS = {
+    'created_at' => { :name => 'Creation Date', :direction => 'desc'},
+    'updated_at' => { :name => 'Last Updated' , :direction => 'desc'},
+    'name'       => { :name => 'Alphabetical' , :direction => 'asc' }
+  }
+
   belongs_to :channel
   has_many :messages
+
+  scope :sort_order_by, lambda { |sort_order| 
+    o = SORT_ORDERS[sort_order  ] ||
+        SORT_ORDERS['created_at']
+
+    order("#{SORT_ORDERS.key(o)} #{o[:direction]}")
+  }
 end

--- a/app/views/chat/messages/discussions.html.haml
+++ b/app/views/chat/messages/discussions.html.haml
@@ -2,6 +2,12 @@
 
 %h1= "Discussions for #{params[:channel]}"
 
+%p
+  Sort by
+  - @discussion_orders.each do |key, order|
+    = link_to_if params[:sort] != key, order[:name], chat_discussions_path(params[:channel], :sort => key)
+    = ',' unless @discussion_orders.keys.last == key
+
 %p= link_to("Back to #{params[:channel]}", chat_messages_path(:channel => params[:channel]))
 
 %ul.discussions

--- a/app/views/chat/messages/discussions.html.haml
+++ b/app/views/chat/messages/discussions.html.haml
@@ -1,0 +1,10 @@
+- title "Discussions for #{params[:channel]}"
+
+%h1= "Discussions for #{params[:channel]}"
+
+%p= link_to("Back to #{params[:channel]}", chat_messages_path(:channel => params[:channel]))
+
+%ul.discussions
+  - @discussions.each do |topic|
+    %li= link_to topic.name, chat_messages_path(:channel => topic.channel.name, :topic => topic.name)
+

--- a/app/views/chat/messages/index.html.haml
+++ b/app/views/chat/messages/index.html.haml
@@ -36,10 +36,12 @@
       );
     }
 
-%h1 IRC Log
+%h1= "IRC Log " + (@topic.present? ? "(#{@topic.name})" : "")
 
 - if @more_messages
   %p= link_to "Load all messages", chat_messages_path(:channel => params[:channel], :full_log => true, :topic => params[:topic])
+
+%p= link_to "Discussions", chat_discussions_path(params[:channel])
 
 %table.messages
   - @messages.each do |message|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ University::Application.routes.draw do
   namespace :chat do
     resources :messages
   end
+  get 'chat/discussions/:channel' => 'chat/messages#discussions', :as => 'chat_discussions'
   
   get "transcripts/:channel" => 'Chat::Messages#transcripts'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ University::Application.routes.draw do
     resources :messages
   end
   get 'chat/discussions/:channel' => 'chat/messages#discussions', :as => 'chat_discussions'
+  get 'chat/discussion/url'       => 'chat/messages#discussion_topic_url'
   
   get "transcripts/:channel" => 'Chat::Messages#transcripts'
 


### PR DESCRIPTION
Hi there,

As a part of s4-e4, I implemented the viewing of discussion topics. Now when users go to the page of an IRC channel, there's a new link that will take them to a list of the various discussions that took place in the channel.

The discussion list is now also sortable by creation date, last updated, and alphabetical order.

This change goes hand-in-hand with the pull request I will be sending for mendibot.

Cheers
