### PR TITLE
Authorization fix and fix for !topic_site command from Mendibot

### DIFF
--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -4,7 +4,7 @@ class Chat::MessagesController < ApplicationController
   before_filter      :find_channel,       :only  => [:index, :discussions]
   skip_before_filter :authenticate_user!
   skip_before_filter :change_password_if_needed
-  before_filter      :authenticate_service, :only => [:create, :discussion_topic_path]
+  before_filter      :authenticate_service, :only => [:create, :discussion_topic_url]
 
   def index
     unless @channel

--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -102,9 +102,14 @@ class Chat::MessagesController < ApplicationController
     channel = Chat::Channel.find_by_name(params[:channel])
     topic   = Chat::Topic.find_by_name(params[:topic])
 
-    url  = chat_messages_url(:channel => channel.name, :topic => topic.name)
-
-    render :text => url
+    if channel.blank?
+      render :text => "Channel doesn't exist", :status => 404
+    elsif topic.blank?
+      render :text => "Nothing has been recorded for topic yet", :status => 404
+    else
+      url  = chat_messages_url(:channel => channel.name, :topic => topic.name)
+      render :text => url
+    end
   end
 
   def transcripts

--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -100,16 +100,16 @@ class Chat::MessagesController < ApplicationController
 
   def discussion_topic_url
     channel = Chat::Channel.find_by_name(params[:channel])
-    topic   = Chat::Topic.find_by_name(params[:topic])
 
     if channel.blank?
       render :text => "Channel doesn't exist", :status => 404
-    elsif topic.blank?
-      render :text => "Nothing has been recorded for topic yet", :status => 404
-    else
-      url  = chat_messages_url(:channel => channel.name, :topic => topic.name)
-      render :text => url
+      return
     end
+
+    topic = Chat::Topic.find_or_create_by_name_and_channel_id(
+              params[:topic], channel.id)
+    url   = chat_messages_url(:channel => channel.name, :topic => topic.name)
+    render :text => url
   end
 
   def transcripts


### PR DESCRIPTION
Hi there Jordan,

This pull request contains two fixes:
1. The path that mendibot uses to get the discussion topic URL from university-web wasn't declared as requiring service authorization as it's supposed to;
2. The !topic_site command is now fixed so that mendibot doesn't crash when a user requests the topic site straight after starting a new discussion.

Thanks!

Raoul Felix
