### PR TITLE
[#5727116] Maps Integration

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,6 @@
 class HomeController < ApplicationController
 
   def show
-
+    render :inline => "<%= user_map_tag %>"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,4 +49,31 @@ module ApplicationHelper
       ].join("\n").html_safe
     end
   end
+
+  # Generates a map containing pins for all user locations. Uses Google Maps
+  # Static API (http://code.google.com/apis/maps/documentation/staticmaps).
+  #
+  # Options:
+  #   width,
+  #   height: the width / height in pixels for the image; default for both
+  #           is 512px
+  #
+  #   zoom_level: zoom level for the map; default is 0 ('world'). See
+  #               http://code.google.com/apis/maps/documentation/staticmaps/#Zoomlevels
+  #               for details.
+  def user_map_tag(options={})
+    width      = options[:width]      || 512
+    height     = options[:height]     || 512
+    zoom_level = options[:zoom_level] || 0
+
+    markers = User.locations.map { |loc| loc.join(',') }.join('%7C')
+
+    url = "http://maps.google.com/maps/api/staticmap?" +
+      "sensor=false" +
+      "&zoom=#{zoom_level}" +
+      "&size=#{width}x#{height}" +
+      "&markers=#{markers}"
+
+    image_tag(url, :alt => 'User Map')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,14 @@ class User < ActiveRecord::Base
     (1..8).map { |a| chars[rand(chars.size)] }.join
   end
 
+  # Retrieves locations for all users as an array of arrays where the inner
+  # array is in the form [latitude, longitude].
+  def self.locations
+    self.select("latitude, longitude")
+      .where("latitude IS NOT NULL AND longitude IS NOT NULL")
+      .map { |u| [u.latitude, u.longitude] }
+  end
+
   def access_level
     AccessLevel::User[read_attribute(:access_level)]
   end

--- a/app/stylesheets/partials/_user.scss
+++ b/app/stylesheets/partials/_user.scss
@@ -1,0 +1,12 @@
+#user_edit {
+  float: left;
+}
+
+#map {
+  width: 200px;
+  height: 200px;
+  border: 1px solid #DDD;
+  float: right;
+  margin: 50px 150px 0 0;
+  @include box-shadow(#AAA, 0px, 0px, 15px);
+}

--- a/app/stylesheets/screen.sass
+++ b/app/stylesheets/screen.sass
@@ -25,6 +25,7 @@
 @import "partials/tabs"
 @import "partials/logs"
 @import "partials/admissions"
+@import "partials/user"
 
 h1, h2, h3 
   margin: 1em 0

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,8 +1,26 @@
+- content_for :header_bottom do
+  %script{ :src => "http://maps.google.com/maps/api/js?sensor=false" }
+  = javascript_include_tag 'jquery.ui.addresspicker'
+  :javascript
+    $(function () {
+      var picker = $("#user_location").addresspicker({
+          elements: {
+            map: "#map",
+            lat: "#user_latitude",
+            lng: "#user_longitude"
+          }
+        }),
+        marker = picker.addresspicker("marker");
+
+      marker.setVisible(true);
+      picker.addresspicker("updatePosition");
+    });
+
 - title 'Edit Personal Information'
 
 %h1.form-header Edit Personal Information
 
-= form_for @user, :html => {:class => 'bp'} do |form|
+= form_for @user, :html => {:class => 'bp', :id => 'user_edit'} do |form|
   = error_messages_for(@user)
   %p
     = form.label :email
@@ -34,6 +52,12 @@
                             :include_blank => true, :default => ""
 
   %p
+    = form.label :location, 'Address / Location'
+    = form.text_field :location
+    = form.hidden_field :latitude
+    = form.hidden_field :longitude
+
+  %p
     = render :partial => "irc_channels", :locals => {:form => form}
   
   - if @user.alumnus?
@@ -62,3 +86,5 @@
   
   %p
     = form.submit 'Update'
+
+%div#map

--- a/db/migrate/20110521170511_add_user_location_info.rb
+++ b/db/migrate/20110521170511_add_user_location_info.rb
@@ -1,0 +1,13 @@
+class AddUserLocationInfo < ActiveRecord::Migration
+  def self.up
+    add_column :users, :location, :string
+    add_column :users, :latitude, :decimal
+    add_column :users, :longitude, :decimal
+  end
+
+  def self.down
+    remove_column :users, :longitude
+    remove_column :users, :latitude
+    remove_column :users, :location
+  end
+end

--- a/public/javascripts/jquery.ui.addresspicker.js
+++ b/public/javascripts/jquery.ui.addresspicker.js
@@ -1,0 +1,170 @@
+/*
+ * jQuery UI addresspicker @VERSION
+ *
+ * Copyright 2010, AUTHORS.txt (http://jqueryui.com/about)
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ * http://jquery.org/license
+ *
+ * http://docs.jquery.com/UI/Progressbar
+ *
+ * Depends:
+ *   jquery.ui.core.js
+ *   jquery.ui.widget.js
+ *   jquery.ui.autocomplete.js
+ */
+(function( $, undefined ) {
+
+$.widget( "ui.addresspicker", {
+    options: {
+      appendAddressString: "",
+        mapOptions: {
+          zoom: 5,
+          center: new google.maps.LatLng(46, 2),
+          scrollwheel: false,
+          mapTypeId: google.maps.MapTypeId.ROADMAP
+        },
+        elements: {
+          map: false,
+          lat: false,
+          lng: false,
+          locality: false,
+          country: false
+        },
+      draggableMarker: true
+    },
+
+    marker: function() {
+        return this.gmarker;
+    },
+
+    map: function() {
+      return this.gmap;
+    },
+
+  updatePosition: function() {
+    this._updatePosition(this.gmarker.getPosition());
+  },
+
+  reloadPosition: function() {
+    this.gmarker.setVisible(true);
+    this.gmarker.setPosition(new google.maps.LatLng(this.lat.val(), this.lng.val()));
+    this.gmap.setCenter(this.gmarker.getPosition());
+  },
+
+  selected: function() {
+    return this.selectedResult;
+  },
+
+    _create: function() {
+      this.geocoder = new google.maps.Geocoder();
+      this.element.autocomplete({
+            source: $.proxy(this._geocode, this),
+            focus:  $.proxy(this._focusAddress, this),
+            select: $.proxy(this._selectAddress, this)
+        });
+
+        this.lat      = $(this.options.elements.lat);
+        this.lng      = $(this.options.elements.lng);
+        this.locality = $(this.options.elements.locality);
+        this.country  = $(this.options.elements.country);
+        if (this.options.elements.map) {
+          this.mapElement = $(this.options.elements.map);
+        this._initMap();
+        }
+    },
+
+  _initMap: function() {
+    if (this.lat && this.lat.val()) {
+      this.options.mapOptions.center = new google.maps.LatLng(this.lat.val(), this.lng.val());
+    }
+
+    this.gmap = new google.maps.Map(this.mapElement[0], this.options.mapOptions);
+    this.gmarker = new google.maps.Marker({
+      position: this.options.mapOptions.center,
+      map:this.gmap,
+      draggable: this.options.draggableMarker});
+    google.maps.event.addListener(this.gmarker, 'dragend', $.proxy(this._markerMoved, this));
+    this.gmarker.setVisible(false);
+  },
+
+  _updatePosition: function(location) {
+    if (this.lat) {
+      this.lat.val(location.lat());
+    }
+    if (this.lng) {
+      this.lng.val(location.lng());
+    }
+  },
+
+  _markerMoved: function() {
+    this._updatePosition(this.gmarker.getPosition());
+  },
+
+  // Autocomplete source method: fill its suggests with google geocoder results
+  _geocode: function(request, response) {
+    var address = request.term, self = this;
+    this.geocoder.geocode( { 'address': address + this.options.appendAddressString}, function(results, status) {
+      if (status == google.maps.GeocoderStatus.OK) {
+        for (var i = 0; i < results.length; i++) {
+          results[i].label =  results[i].formatted_address;
+        };
+      }
+      response(results);
+    })
+  },
+
+  _findInfo: function(result, type) {
+    for (var i = 0; i < result.address_components.length; i++) {
+      var component = result.address_components[i];
+      if (component.types.indexOf(type) !=-1) {
+        return component.long_name;
+      }
+    }
+    return false;
+  },
+
+  _focusAddress: function(event, ui) {
+    var address = ui.item;
+    if (!address) {
+      return;
+    }
+
+    if (this.gmarker) {
+      this.gmarker.setPosition(address.geometry.location);
+      this.gmarker.setVisible(true);
+
+      this.gmap.fitBounds(address.geometry.viewport);
+    }
+    this._updatePosition(address.geometry.location);
+
+    if (this.locality) {
+      this.locality.val(this._findInfo(address, 'locality'));
+    }
+    if (this.country) {
+      this.country.val(this._findInfo(address, 'country'));
+    }
+  },
+
+  _selectAddress: function(event, ui) {
+    this.selectedResult = ui.item;
+  }
+});
+
+$.extend( $.ui.addresspicker, {
+    version: "@VERSION"
+});
+
+
+// make IE think it doesn't suck
+if(!Array.indexOf){
+    Array.prototype.indexOf = function(obj){
+        for(var i=0; i<this.length; i++){
+            if(this[i]==obj){
+                return i;
+            }
+        }
+        return -1;
+    }
+}
+
+})( jQuery );

--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  include ApplicationHelper
+
+  context "user map tag helper" do
+    # NOTE: This would be faster if a mocking framework was pulled in then we
+    # could just mock the locations class method and not have to hit the db
+    setup do
+      [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]].each do |loc|
+        Factory(:user, :latitude => loc[0], :longitude => loc[1])
+      end
+    end
+
+    test "generates map tag with default options" do
+      expected = '<img ' +
+        'alt="User Map" ' +
+        'src="http://maps.google.com/maps/api/staticmap?' +
+        'sensor=false' +
+        '&amp;zoom=0' +
+        '&amp;size=512x512' +
+        '&amp;markers=1.0,2.0%7C3.0,4.0%7C5.0,6.0' +
+        '" />'
+
+      assert_equal expected, user_map_tag
+    end
+
+    test "generates map tag with custom width" do
+      expected = '<img ' +
+        'alt="User Map" ' +
+        'src="http://maps.google.com/maps/api/staticmap?' +
+        'sensor=false' +
+        '&amp;zoom=0' +
+        '&amp;size=250x512' +
+        '&amp;markers=1.0,2.0%7C3.0,4.0%7C5.0,6.0' +
+        '" />'
+
+      assert_equal expected, user_map_tag(:width => 250)
+    end
+
+    test "generates map tag with custom height" do
+      expected = '<img ' +
+        'alt="User Map" ' +
+        'src="http://maps.google.com/maps/api/staticmap?' +
+        'sensor=false' +
+        '&amp;zoom=0' +
+        '&amp;size=512x100' +
+        '&amp;markers=1.0,2.0%7C3.0,4.0%7C5.0,6.0' +
+        '" />'
+
+      assert_equal expected, user_map_tag(:height => 100)
+    end
+
+    test "generates map tag with custom zoom level" do
+      expected = '<img ' +
+        'alt="User Map" ' +
+        'src="http://maps.google.com/maps/api/staticmap?' +
+        'sensor=false' +
+        '&amp;zoom=10' +
+        '&amp;size=512x512' +
+        '&amp;markers=1.0,2.0%7C3.0,4.0%7C5.0,6.0' +
+        '" />'
+
+      assert_equal expected, user_map_tag(:zoom_level => 10)
+    end
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -211,6 +211,25 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  context "retrieving user locations" do
+    setup do
+      @expected = [[12.3456, 78.9012], [34.5678, 90.1234]]
+
+      @expected.each do |loc|
+        Factory.create(:user, :latitude => loc[0], :longitude => loc[1])
+      end
+    end
+
+    test "retrieve all user locations" do
+      assert_equal @expected, User.locations
+    end
+
+    test "retrieve locations only with a latitude & longitude" do
+      Factory.create(:user)
+      assert_equal @expected, User.locations
+    end
+  end
+
   private
 
   def swap_access_level_definitions(klass)


### PR DESCRIPTION
- Add location info to user table.
- Add class method for retrieving user locations.
- Create a _user.scss partial for user edit view styles
- Import the _user.scss partial in screen.sass
- Add javascript logic for address picker to user edit view
- Add fields for location, latitude & longitude in user edit view
- Create a placeholder for map in user edit view
- Add jquery.ui.addresspicker to public/javascripts
- Create a user_map helper that inserts a map image with pins for all user
  locations
- Put an example of how to use the user_map_tag in the home controller
- Add application helper test file with tests for user_map_tag helper
- Documentation.

A couple of notes:
1) Instead of creating a partial for the map I created a view helper. That way you can just do "user_map_tag" in any view and it will draw the map. The helper takes options for size and zoom level. You can see an example of the map by going to '/home'.

2) The geocoding is only happening on the client side in the jQuery addresspicker. Ideally, the geocoding should also be done on the server side either in a before_save callback or from a job queue. We could use Geokit[1](http://geokit.rubyforge.org/) but I didn't want to pull in another dependency without asking first.

3) The tests for the user_map_tag helper could be cleaned up a bit by using mocks but I didn't know if anyone had a preference for one (I usually use Mocha). Let me know and if you want I can pull it in and update the tests.
