### PR TITLE
Export Assignments

### DIFF
--- a/app/controllers/courses/assignments_controller.rb
+++ b/app/controllers/courses/assignments_controller.rb
@@ -10,6 +10,10 @@ class Courses::AssignmentsController < Courses::Base
     respond_to do |format|
       format.html
       format.text { render :text => @assignment.notes }
+      format.gz do
+        send_data Assignment::Exporter.new(@assignment).to_gzip,
+                  :filename => "#{@assignment.name.parameterize}.gz"
+      end
     end
   end
 

--- a/app/controllers/courses/assignments_controller.rb
+++ b/app/controllers/courses/assignments_controller.rb
@@ -11,7 +11,8 @@ class Courses::AssignmentsController < Courses::Base
       format.html
       format.text { render :text => @assignment.notes }
       format.gz do
-        send_data Assignment::Exporter.new(@assignment).to_gzip,
+        serializer = params[:as] || :json
+        send_data Assignment::Exporter.new(@assignment).to_gzip(serializer),
                   :filename => "#{@assignment.name.parameterize}.gz"
       end
     end

--- a/app/models/assignment/exporter.rb
+++ b/app/models/assignment/exporter.rb
@@ -21,6 +21,7 @@ class Assignment::Exporter
   # returns a tempfile containing the gzipped export
   def to_file
     file = Tempfile.new('assignment-exporter')
+    file.binmode
     file << to_gzip
     file.rewind
     file

--- a/app/models/assignment/exporter.rb
+++ b/app/models/assignment/exporter.rb
@@ -1,75 +1,92 @@
-class Assignment::Exporter
-  def initialize(assignment)
-    @assignment = assignment
-  end
+class Assignment
+  class Exporter
+    def initialize(assignment)
+      @assignment = assignment
+    end
 
-  # returns a hash of the assignment that can be serialized
-  def export
-    export_assignment(@assignment)
-  end
+    # returns a hash of the assignment that can be serialized
+    def export
+      export_assignment(@assignment)
+    end
 
-  # returns a string containing the export serialized to yaml
-  def to_yaml
-    export.to_yaml
-  end
+    # returns a string containing the export serialized to yaml
+    def to_yaml
+      export.to_yaml
+    end
 
-  # returns a string containing the gzipped yaml
-  def to_gzip
-    ActiveSupport::Gzip.compress to_yaml
-  end
+    # returns a string containing the export serialized to json
+    def to_json
+      export.to_json
+    end
 
-  # returns a tempfile containing the gzipped export
-  def to_file
-    file = Tempfile.new('assignment-exporter')
-    file.binmode
-    file << to_gzip
-    file.rewind
-    file
-  end
+    # returns a string containing the gzipped serialized data
+    #
+    # you can pass it an optional parameter to change the format:
+    #
+    #    to_gzip(:yaml) # default
+    #
+    #    to_gzip(:json)
+    def to_gzip(format = :yaml)
+      format_method = "to_#{format}"
+      raise ArgumentError, "Unknown format" unless respond_to?(format_method)
+      serialized = send format_method
 
-  def to_s
-    "<Assignment::Exporter assignment=#{@assignment.id}>"
-  end
+      ActiveSupport::Gzip.compress serialized
+    end
 
-  private
-  def export_assignment(assignment)
-    data = {
-      :name        => assignment.name,
-      :description => assignment.description
-    }
+    # returns a tempfile containing the gzipped export
+    def to_file(format = :yaml)
+      file = Tempfile.new('assignment-exporter')
+      file.binmode
+      file << to_gzip(format)
+      file.rewind
+      file
+    end
 
-    submissions = assignment.submissions.includes(:comments   => :user,
-                                                  :activities => :user)
+    def to_s
+      "<Assignment::Exporter assignment=#{@assignment.id}>"
+    end
 
-    data[:submissions] = submissions.map { |s| export_submission(s) }
+    private
+    def export_assignment(assignment)
+      data = {
+        :name        => assignment.name,
+        :description => assignment.description
+      }
 
-    data
-  end
+      submissions = assignment.submissions.includes(:comments   => :user,
+                                                    :activities => :user)
 
-  def export_submission(submission)
-    data = {
-      :description => submission.description,
-      :status      => submission.status.try(:name)
-    }
+      data[:submissions] = submissions.map { |s| export_submission(s) }
 
-    data[:comments]   = submission.comments.map   { |c| export_comment c }
-    data[:activities] = submission.activities.map { |a| export_activity a }
-    data
-  end
+      data
+    end
 
-  def export_comment(comment)
-    {
-      :updated_at   => comment.updated_at,
-      :user         => comment.user.name,
-      :comment_text => comment.comment_text
-    }
-  end
+    def export_submission(submission)
+      data = {
+        :description => submission.description,
+        :status      => submission.status.try(:name)
+      }
 
-  def export_activity(activity)
-    {
-      :updated_at  => activity.updated_at,
-      :user        => activity.user.name,
-      :description => activity.description
-    }
+      data[:comments]   = submission.comments.map   { |c| export_comment c }
+      data[:activities] = submission.activities.map { |a| export_activity a }
+      data
+    end
+
+    def export_comment(comment)
+      {
+        :updated_at   => comment.updated_at,
+        :user         => comment.user.name,
+        :comment_text => comment.comment_text
+      }
+    end
+
+    def export_activity(activity)
+      {
+        :updated_at  => activity.updated_at,
+        :user        => activity.user.name,
+        :description => activity.description
+      }
+    end
   end
 end

--- a/app/models/assignment/exporter.rb
+++ b/app/models/assignment/exporter.rb
@@ -1,0 +1,74 @@
+class Assignment::Exporter
+  def initialize(assignment)
+    @assignment = assignment
+  end
+
+  # returns a hash of the assignment that can be serialized
+  def export
+    export_assignment(@assignment)
+  end
+
+  # returns a string containing the export serialized to yaml
+  def to_yaml
+    export.to_yaml
+  end
+
+  # returns a string containing the gzipped yaml
+  def to_gzip
+    ActiveSupport::Gzip.compress to_yaml
+  end
+
+  # returns a tempfile containing the gzipped export
+  def to_file
+    file = Tempfile.new('assignment-exporter')
+    file << to_gzip
+    file.rewind
+    file
+  end
+
+  def to_s
+    "<Assignment::Exporter assignment=#{@assignment.id}>"
+  end
+
+  private
+  def export_assignment(assignment)
+    data = {
+      :name        => assignment.name,
+      :description => assignment.description
+    }
+
+    submissions = assignment.submissions.includes(:comments   => :user,
+                                                  :activities => :user)
+
+    data[:submissions] = submissions.map { |s| export_submission(s) }
+
+    data
+  end
+
+  def export_submission(submission)
+    data = {
+      :description => submission.description,
+      :status      => submission.status.try(:name)
+    }
+
+    data[:comments]   = submission.comments.map   { |c| export_comment c }
+    data[:activities] = submission.activities.map { |a| export_activity a }
+    data
+  end
+
+  def export_comment(comment)
+    {
+      :updated_at   => comment.updated_at,
+      :user         => comment.user.name,
+      :comment_text => comment.comment_text
+    }
+  end
+
+  def export_activity(activity)
+    {
+      :updated_at  => activity.updated_at,
+      :user        => activity.user.name,
+      :description => activity.description
+    }
+  end
+end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -6,3 +6,4 @@
 
 
 Mime::Type.register "application/zip", :zip
+Mime::Type.register "application/gzip", :gz

--- a/test/unit/assignment/exporter_test.rb
+++ b/test/unit/assignment/exporter_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class Assignment::ExporterTest < ActiveSupport::TestCase
+  setup do
+    @assignment = Factory(:assignment, :description => "Assignment desc")
+    @submission = Factory(:submission, :description => "My project",
+                                       :assignment  => @assignment)
+
+    @exporter   = Assignment::Exporter.new(@assignment)
+  end
+
+  context "#export" do
+    test "exports assignment details" do
+      data = @exporter.export
+
+      assert_equal @assignment.name,        data[:name]
+      assert_equal @assignment.description, data[:description]
+    end
+
+    test "exports submission details" do
+      @submission.update_attributes :status => Factory(:submission_status)
+
+      data            = @exporter.export
+      submission_data = data[:submissions].first
+
+      assert_equal @submission.description, submission_data[:description]
+      assert_equal @submission.status.name, submission_data[:status]
+    end
+
+    test "exports comment details" do
+      comment = @submission.comments.create(:user          => @submission.user,
+                                            :comment_text => "This is text")
+
+      data         = @exporter.export
+      comment_data = data[:submissions].first[:comments].first
+
+      assert_equal comment.updated_at,   comment_data[:updated_at]
+      assert_equal comment.user.name,    comment_data[:user]
+      assert_equal comment.comment_text, comment_data[:comment_text]
+    end
+
+    test "exports activity details" do
+      activity = Factory(:activity, :submission => @submission,
+                                    :user       => @submission.user)
+
+      data          = @exporter.export
+      activity_data = data[:submissions].first[:activities].first
+
+      assert_equal activity.updated_at,  activity_data[:updated_at]
+      assert_equal activity.user.name,   activity_data[:user]
+      assert_equal activity.description, activity_data[:description]
+    end
+  end
+end


### PR DESCRIPTION
Was [my community project](http://university.rubymendicant.com/courses/11/assignments/49/submissions/699/edit). 

It defaults to compressed json, but you can switch to compressed yaml by adding the query ?as=yaml. 

May even be nice to add the ability to output uncompressed json or yaml. It'd just be adding some additional format blocks. I'd be happy to do that if you like. Just let me know.
