### PR TITLE
listing of course participants is now grouped by role in the course

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,5 @@ group :test do
   gem "test-unit"
   gem 'mocha'
   gem 'test_notifier', '~> 0.3.6'
+  gem 'launchy'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     childprocess (0.1.6)
       ffi (~> 0.6.3)
     compass (0.10.6)
+    configuration (1.2.0)
     contest (0.1.2)
     culerity (0.2.15)
     erubis (2.6.6)
@@ -74,6 +75,9 @@ GEM
     i18n (0.4.2)
     json (1.5.1)
     json_pure (1.5.1)
+    launchy (0.4.0)
+      configuration (>= 0.0.5)
+      rake (>= 0.8.1)
     mail (2.2.15)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
@@ -150,6 +154,7 @@ DEPENDENCIES
   factory_girl_rails
   haml
   json
+  launchy
   mocha
   octokit
   pg

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,7 +14,12 @@ class CoursesController < ApplicationController
                                               :page     => params[:activity_page])
 
     @users = User.search(params[:search], params[:user_page],
-      :sort => :name, :course_id => @course.id, :per_page => 7)
+      :sort => "course_memberships.access_level ASC",
+      :course_id => @course.id, :per_page => 7)
+      
+    @grouped_users = @users.group_by do |user| 
+      user.current_course_membership(@course).access_level.to_s.humanize
+    end
       
     respond_to do |format|
       format.html

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,4 +49,8 @@ module ApplicationHelper
       ].join("\n").html_safe
     end
   end
+  
+  def get_last(collection_size, index) 
+    collection_size == index ? "last" : ""
+  end
 end

--- a/app/helpers/courses_helper.rb
+++ b/app/helpers/courses_helper.rb
@@ -7,4 +7,5 @@ module CoursesHelper
       ''
     end
   end
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,10 +72,9 @@ class User < ActiveRecord::Base
         where(["course_memberships.course_id = ?", options[:course_id].to_i])
     end
 
-    # TODO: sort_by will trigger the sql query, instead of using a relation.
-    # The pagination would be created over the result array. Use a relation.
     if options[:sort]
-      results = results.sort_by(&options[:sort])
+      results = options[:sort].is_a?(Symbol) ? 
+        results.order(&options[:sort]) : results.order(options[:sort])
     else
       results = results.order('email')
     end
@@ -168,6 +167,10 @@ class User < ActiveRecord::Base
 
   def mentor_courses
     course_by_membership_type("mentor")
+  end
+  
+  def current_course_membership(course)
+    course_memberships.where(:course_id => course.id).first
   end
 
   private

--- a/app/stylesheets/partials/_directory.sass
+++ b/app/stylesheets/partials/_directory.sass
@@ -31,6 +31,8 @@
       font-size: 0.75em
       margin-top: 0.1em
       color:  #777
+  .user.last
+    border-bottom: none
       
 #directory_search
   position: relative

--- a/app/views/courses/show.html.haml
+++ b/app/views/courses/show.html.haml
@@ -38,6 +38,7 @@
       jQuery("label.infield").inFieldLabels();
       
       UW.Timezones.init();
+      
     });
 
 - content_for :breadcrumbs do
@@ -96,11 +97,13 @@
           :class => "infield"
         = text_field_tag :search, params[:search]
         = submit_tag "Search"
-  
-      - @users.each do |user|
-        = render :partial => '/users/user', :locals => { :user => user, 
-          :roles => user.course_memberships.where(:course_id => @course.id)}
-
+      
+      - @grouped_users.keys.each do |role|
+        %h3= role.pluralize
+        - group_size = @grouped_users[role].length
+        - @grouped_users[role].each_with_index do |user, i| i+=1
+          = render :partial => '/users/user', :locals => { :user => user, :roles => role, :css_class => "#{role.downcase} #{get_last(group_size, i)}" } 
+      
       = will_paginate @users, :params => {:anchor => "participants"}, 
         :param_name => "user_page"
     

--- a/app/views/users/_user.html.haml
+++ b/app/views/users/_user.html.haml
@@ -1,10 +1,12 @@
-= link_to  user_path(user) do
-  .user
+= link_to user_path(user) do
+  %div{:class => "user #{css_class}"}
     .icon= image_tag user.gravatar_url(48)
     .name= user.name
     .since
       %span.type
-        - if defined? roles
+        - if defined? roles && roles.is_a?(String)
+          = roles + ": "
+        - elsif defined? roles
           = roles.map {|cm| cm.access_level.to_s.humanize }.join(', ') + ": "
         - else
           = user_type(user)

--- a/test/integration/courses/directory_test.rb
+++ b/test/integration/courses/directory_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+
+module Courses
+  class DirectoryTest < ActionDispatch::IntegrationTest
+    
+    story "As a student I want to view the paricipants of my course" do
+      
+      setup do
+        @course = Factory(:course)
+        @user = sign_user_in
+        Factory(:course_membership, :user => @user, :course => @course)
+        2.times do |i|
+          user = Factory(:user, :nickname => "Student #{i+1}")
+          Factory(:course_membership, :user => user, :course => @course)
+        end
+      end
+      
+      scenario "view all participants" do
+        
+        visit course_path(@course, :anchor => "participants")
+        
+        within("div#directory") do
+          assert_content "Students"
+          assert_css("div.user", :count => 3)
+          assert_content @user.nickname
+          assert_content "Student 1"
+          assert_content "Student 2"
+        end
+      end
+      
+      story "and participants should be grouped by their role" do
+        
+        setup do
+          @instructor = Factory(:user, :nickname => "Ida Instructress")
+          Factory(:course_membership, :user => @instructor, :course => @course, :access_level => "instructor")
+      
+          @mentor = Factory(:user, :nickname => "Manny Mentor")
+          Factory(:course_membership, :user => @mentor, :course => @course, :access_level => "mentor")
+        end
+        
+        scenario "role headings are visible" do
+          
+          visit course_path(@course, :anchor => "participants")
+    
+          within("div#directory") do
+            assert_css("h3", :text => 'Instructors')
+            assert_css("div.user.instructor", :count => 1)
+            assert_css("h3", :text => 'Mentors')
+            assert_css("div.user.mentor", :count => 1)
+            assert_css("h3", :text => 'Students')
+            assert_css("div.user.student", :count => 3)
+          end
+        end
+        
+        scenario "roles are correctly assigned" do
+          
+          visit course_path(@course, :anchor => "participants")
+          
+          within("div.instructor") do
+            assert_content "Ida Instructress"
+          end
+          within("div.mentor") do
+            assert_content "Manny Mentor"
+          end
+        end
+        
+        story "pagination works over grouped participants" do
+          # testing for currently set page size of 7
+          setup do
+            3.times do |i|
+              user = Factory(:user, :nickname => "Additional Student #{i+1}")
+              Factory(:course_membership, :user => user, :course => @course)
+            end
+          end
+
+          scenario "when clicking the next page, one student is visible" do
+            visit course_path(@course, :anchor => "participants")
+            click_link_within("div.pagination", "2")
+            
+            within("div#directory") do
+              assert_css("h3", :text => 'Students')
+              assert_css("div.student", :count => 1)
+            end
+          end
+
+        end
+      end
+    end    
+  end
+end


### PR DESCRIPTION
Hey Jordan,

I implemented the feature of grouping course participants by their role in the particular course on the courses/show page (under the #participants anchor). I also added some integration tests for that feature. The current sorting lists instructors first, then mentors and then students. Pagination is done over one single collection of pre-sorted users.

Let me know if you'd like me to change/correct anything.

(I added the launchy gem to the Gemfile, since I like using the save_and_open_page method for debugging integration tests. I can remove it again if you don't want it.)

Thanks,

Andrea
