### PR TITLE
Add the quoted text from the commenter when replying

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 class CommentsController < ApplicationController
   before_filter :find_comment,     :only => [:show, :update, :destroy]
-  before_filter :commentator_only, :only => [:show, :update, :destroy]
+  before_filter :comment_viewer_only, :only => [:show]
+  before_filter :commentator_only, :only => [:update, :destroy]
 
   def show
     render :text => @comment.comment_text
@@ -26,6 +27,13 @@ class CommentsController < ApplicationController
 
   def find_comment
     @comment = Comment.find(params[:id])
+  end
+
+  def comment_viewer_only
+    raise "Access Denied" unless @comment.user == current_user || (
+      @comment.commentable.is_a?(Assignment::Submission) &&
+      @comment.commentable.assignment.course.users.include?(current_user)
+    )
   end
 
   def commentator_only

--- a/app/stylesheets/partials/_comments.sass
+++ b/app/stylesheets/partials/_comments.sass
@@ -93,6 +93,7 @@
         display: inline-block
         float: right
         padding-top: 5px
+        margin-left: 5px
         color: #888
         font-size: 0.9em
         cursor: default

--- a/public/javascripts/uw.comments.js
+++ b/public/javascripts/uw.comments.js
@@ -46,7 +46,17 @@ UW.Comments.init = function(commentsPath){
     reply_container.find("a:first").attr('href', '#' + index)
                                     .text('Comment #' + index);
     reply_container.show();
-    $("form.new_comment textarea").focus();
+    var input = $("form.new_comment textarea");
+    $.ajax({
+      url: "/comments/"+id,
+      success: function(text){
+        quoted = $.map(text.split("\n"), function(line){
+          return line ? "> "+line : "";
+        }).join("\n")+"\n\n";
+        input.val(input.val() + quoted).focus();
+        input.scrollTo('max');
+      }
+    });
   });
 
   $('form.new_comment #in_reply_to a.cancel_reply').click(function(e){


### PR DESCRIPTION
This quote the message you respond to, allowing you to easily answer inline, while keeping the original markdown formatting.
