### PR TITLE
Scope search within channel

### DIFF
--- a/app/controllers/chat/messages_controller.rb
+++ b/app/controllers/chat/messages_controller.rb
@@ -50,7 +50,7 @@ class Chat::MessagesController < ApplicationController
     #strip non-word chars, which confuse postgresql's search method
     params[:search].gsub!(/\W/," ")
 
-    @messages = Chat::Message.search({body: params[:search]})
+    @messages = Chat::Message.search_within_channel(@channel, {body: params[:search]})
     @num_results = @messages.count.to_s
 
     respond_to do |format|

--- a/app/models/chat/message.rb
+++ b/app/models/chat/message.rb
@@ -6,6 +6,10 @@ module Chat
     belongs_to :handle
     belongs_to :topic
 
+    def self.search_within_channel(channel, search_options)
+      where(:channel_id => channel.id).search(search_options)
+    end
+
     def check_action
       regex = /^\u0001ACTION(.*)\u0001$/
       if body =~ regex

--- a/test/functional/chat/messages_controller_test.rb
+++ b/test/functional/chat/messages_controller_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class Chat::MessagesControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+
+  def setup
+    @channel_one = Factory(:chat_channel, :public => true, :name => 'Channel One')
+    @channel_two = Factory(:chat_channel, :public => true, :name => 'Channel Two')
+    Factory(:chat_message, :body => 'Channel One result', :channel => @channel_one)
+    Factory(:chat_message, :body => 'Channel Two result', :channel => @channel_two)
+  end
+
+  test 'search scopes the results to the given channel only' do
+    get :search, :channel => @channel_one.name, :search => 'result'
+
+    assert_response :success
+    assert_select 'h3', /1/
+    assert_select 'tr', { :text => /One/, :count => 1 }
+    assert_select 'tr', { :text => /Two/, :count => 0 }
+  end
+end


### PR DESCRIPTION
Hi,

Fixing the scope bug with the irc log searches.

I'm accepting comments about the test, I'm not familiar with rails assert_select, so maybe their is better way to verify than.
I thought about splitting the test into the model and mocking the call in to controller, but I prefer to have it as it is to verify correctness.
